### PR TITLE
Handle dates differently

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -65,7 +65,6 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   private static final String FIREBASE_ANALYTICS_KEY = "Firebase";
   private final Logger logger;
   private final FirebaseAnalytics firebaseAnalytics;
-  static final SimpleDateFormat FIREBASE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
   private static final Map<String, String> EVENT_MAPPER = createEventMap();
 
   private static Map<String, String> createEventMap() {
@@ -136,17 +135,10 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
     Map<String, Object> traits = identify.traits();
     for (Map.Entry<String, Object> entry : traits.entrySet()) {
       String trait = entry.getKey();
-      Object value = entry.getValue();
+      String value = String.valueOf(entry.getValue());
       trait = makeKey(trait);
-      String formattedValue;
-      if (value instanceof Date) {
-        Date dateValue = (Date) value;
-        formattedValue = FIREBASE_FORMAT.format(dateValue);
-      } else {
-        formattedValue = String.valueOf(value);
-      }
-      firebaseAnalytics.setUserProperty(trait, formattedValue);
-      logger.verbose("firebaseAnalytics.setUserProperty(%s, %s);", trait, formattedValue);
+      firebaseAnalytics.setUserProperty(trait, value);
+      logger.verbose("firebaseAnalytics.setUserProperty(%s, %s);", trait, value);
     }
   }
 
@@ -190,10 +182,6 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
       } else if (value instanceof Long) {
         long longValue = (long) value;
         bundle.putLong(property, longValue);
-      } else if (value instanceof Date) {
-        Date dateValue = (Date) value;
-        String formattedDate = FIREBASE_FORMAT.format(dateValue);
-        bundle.putString(property, formattedDate);
       } else {
         String stringValue = String.valueOf(value);
         bundle.putString(property, stringValue);

--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -20,8 +20,6 @@ import com.segment.analytics.integrations.TrackPayload;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Date;
-import java.text.SimpleDateFormat;
 
 import static com.segment.analytics.internal.Utils.hasPermission;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -73,7 +73,7 @@ public class FirebaseTest {
                 .putFirstName("bar")
                 .putLastName("baz")
                 .putValue("anonymousId", 123)
-                .putValue("Sign Up Date", new Date())
+                .putValue("Sign Up Date", new Date(117, 6, 14))
                 .putValue("  extra spaces        ", "bar");
 
 
@@ -83,7 +83,7 @@ public class FirebaseTest {
         verify(firebase).setUserProperty("firstName", "bar");
         verify(firebase).setUserProperty("lastName", "baz");
         verify(firebase).setUserProperty("anonymousId", "123");
-        verify(firebase).setUserProperty("Sign_Up_Date", "2017-09-07");
+        verify(firebase).setUserProperty("Sign_Up_Date", "Fri Jul 14 00:00:00 PDT 2017");
         verify(firebase).setUserProperty("extra_spaces", "bar");
     }
 
@@ -110,7 +110,7 @@ public class FirebaseTest {
         expected.putInt("integer", 1);
         expected.putDouble("double", 1.0);
         expected.putString("string", "foo");
-        expected.putString("date", "2017-01-01");
+        expected.putString("date", "Sun Jan 01 00:00:00 PST 2017");
         expected.putString("key_with_spaces", "bar");
         expected.putDouble("value", 100.0);
         expected.putString("currency", "USD");


### PR DESCRIPTION
* No longer reformats date objects to "YYYY-MM-DD"
* Date objects are stringified and sent to Firebase without any formatting changes
* Tests updated to reflect functionality change
