### PR TITLE
Bump firebase SDK to 17.0.1 + prerequisites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,14 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.3'
+    classpath 'com.android.tools.build:gradle:5.5.1'
     classpath 'com.f2prateek.javafmt:javafmt:0.1.6'
+    classpath 'com.google.gms:google-services:4.2.0'
   }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.android.application'
 apply plugin: 'com.f2prateek.javafmt'
 
 android {
@@ -41,7 +43,7 @@ dependencies {
     }
   }
 
-  implementation 'com.google.firebase:firebase-core:16.0.3'
+  implementation 'com.google.firebase:firebase-core:17.0.1'
 
   implementation 'com.segment.analytics.android:analytics:4.2.6'
 
@@ -62,5 +64,6 @@ dependencies {
   testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
 }
 
+apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.f2prateek.javafmt'
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
[Submitting this to hopefully save the team some time if we can get PM approval, but please note that I'm not familiar with Android conventions and don't currently have an env in which to test out this change -- please review and test before merging. Also note while the branch name points to '17.0.0'; the newer 17.0.1 actually changed between creating the branch and the commit.]

End goal: bump the Firebase SDK to latest (17.0.1) per https://segment.atlassian.net/browse/DEST-854  .

In addition to updating L46, I also included the following changes, which IIUC (from https://firebase.google.com/docs/android/setup?origin_team=T026HRLC7#add-sdks ) are prerequisites. I'm Android-naive and just following the docs by the letter, so please review my assumptions.
- bumped gradle version to 5.5.1 per the '4.1 or later' prerequisite on L8  
- added google-services:4.2.0 to dependencies on L10 per doc section 2.a. and the google-services plugin on L67 per section 2.b.
- added 'com.android.application' plugin on L15