### PR TITLE
Try to enable manual screen tracking

### DIFF
--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -1,7 +1,10 @@
 package com.segment.analytics.android.integration.firebase;
 
 import android.content.Context;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.app.Activity;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.segment.analytics.Properties;
@@ -9,6 +12,7 @@ import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
+import com.segment.analytics.integrations.ScreenPayload;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -34,6 +38,8 @@ import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.isNull;
 
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({ "org.mockito.*", "org.roboelectric.*", "android.*" })
@@ -141,6 +147,16 @@ public class FirebaseTest {
         expected.putString("extra_spaces", "baz");
 
         verify(firebase).logEvent(eq("foo_bar"), bundleEq(expected));
+    }
+
+    @Test
+    public void trackScreenWithName() {
+        final Activity activity = PowerMockito.mock(Activity.class);
+        integration.onActivityStarted(activity);
+
+        integration.screen(new ScreenPayload.Builder().anonymousId("1234").name("home_screen").build());
+
+        verify(firebase).setCurrentScreen(any(Activity.class), eq("home_screen"), (String) isNull());
     }
 
     /**


### PR DESCRIPTION
Segment’s documentation mentions that screen events are not passed through to the Firebase SDK because Firebase does automatic screen tracking. (https://segment.com/docs/connections/destinations/catalog/firebase/#screen)
However, it mentions that Automatic+Manual screen tracking should be supported, but this currently does not work because Segment does not forward the manual screen tracking events. 

[Like on iOS](https://github.com/segmentio/analytics-ios-integrations/pull/11), this attempts to let explicitly tracked screens in analytics-react-native using analytics.screen actually be tracked in Firebase.

I haven't been able to test this code locally, since I'm not very familiar with Gradle, and how to get a locally edited version of this to run in my project, but I'm opening this in any case as an example of a matching implementation of an iOS fix - and hoping someone knows how to test this, or can think of an alternative implementation ✌️ 