### PR TITLE
[STRATCONN-39] Enable manual screen tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.1.0 / 2020-02-20
+==================
+  * Add support for explicitly tracking screen calls.
+
 2.0.0 / 2019-11-15
 ==================
 *(Supports Android 29+ and Gradle 3.2.1+)*
@@ -37,4 +41,4 @@ Version 1.0.0 (7th September, 2017)
 ===================================
 *(Supports analytics-android 4.2.6 and Firebase Core 11.2.0)*
 
-  * Initial Release 
+  * Initial Release

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=2.0.0-SNAPSHOT
+VERSION=2.1.0-SNAPSHOT
 
 POM_ARTIFACT_ID=firebase
 POM_PACKAGING=aar

--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -65,6 +65,7 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   private final Logger logger;
   private final FirebaseAnalytics firebaseAnalytics;
   private static final Map<String, String> EVENT_MAPPER = createEventMap();
+  private Activity currentActivity;
 
   private static Map<String, String> createEventMap() {
     Map<String, String> EVENT_MAPPER = new HashMap<>();
@@ -101,8 +102,6 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
     PROPERTY_MAPPER.put("currency", Param.CURRENCY);
     return PROPERTY_MAPPER;
   }
-
-  private Activity currentActivity;
 
   public FirebaseIntegration(Context context, Logger logger) {
     this.logger = logger;

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -1,18 +1,16 @@
 package com.segment.analytics.android.integration.firebase;
 
-import android.content.Context;
-import android.content.pm.ActivityInfo;
-import android.content.pm.PackageManager;
-import android.os.Bundle;
 import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.segment.analytics.Properties;
 import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
-import com.segment.analytics.integrations.TrackPayload;
 import com.segment.analytics.integrations.ScreenPayload;
+import com.segment.analytics.integrations.TrackPayload;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,9 +35,9 @@ import java.util.Map;
 import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({ "org.mockito.*", "org.roboelectric.*", "android.*" })

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -1,7 +1,10 @@
 package com.segment.analytics.android.integration.firebase;
 
 import android.content.Context;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.app.Activity;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.segment.analytics.Properties;
@@ -9,6 +12,7 @@ import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
+import com.segment.analytics.integrations.ScreenPayload;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -34,6 +38,8 @@ import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.isNull;
 
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({ "org.mockito.*", "org.roboelectric.*", "android.*" })
@@ -141,6 +147,16 @@ public class FirebaseTest {
         expected.putString("extra_spaces", "baz");
 
         verify(firebase).logEvent(eq("foo_bar"), bundleEq(expected));
+    }
+
+    @Test
+    public void trackScreenWithName() {
+        final Activity activity = PowerMockito.mock(Activity.class);
+        integration.onActivityStarted(activity);
+
+        integration.screen(new ScreenPayload.Builder().anonymousId("1234").name("home_screen").build());
+
+        verify(firebase).setCurrentScreen(any(Activity.class), eq("home_screen"), (String) isNull());
     }
 
     /**


### PR DESCRIPTION
**NOTE: Changes were migrated from PR #26 to update SNAPSHOT and prep for release.** 

**Changes:**
Segment’s documentation mentions that screen events are not passed through to the Firebase SDK because Firebase does automatic screen tracking. (https://segment.com/docs/connections/destinations/catalog/firebase/#screen)
However, it mentions that Automatic+Manual screen tracking should be supported, but this currently does not work because Segment does not forward the manual screen tracking events.

Like on iOS, this attempts to let explicitly tracked screens in analytics-react-native using analytics.screen actually be tracked in Firebase.

I haven't been able to test this code locally, since I'm not very familiar with Gradle, and how to get a locally edited version of this to run in my project, but I'm opening this in any case as an example of a matching implementation of an iOS fix - and hoping someone knows how to test this, or can think of an alternative implementation ✌️