### PR TITLE
Added check on makeKey to replace dash from event-names

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -215,6 +215,8 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   public static String makeKey(String key) {
     if (key.contains(".")) {
       key = key.trim().replace(".", "_");
+    } else if (key.contains("-")) {
+      key = key.trim().replace("-", "_");
     } else {
       key = key.trim().replaceAll(" ", "_");
     }

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -157,6 +157,18 @@ public class FirebaseTest {
         verify(firebase).setCurrentScreen(any(Activity.class), eq("home_screen"), (String) isNull());
     }
 
+    @Test
+    public void makeKeyWithDash() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test-event-dashed").build());
+        verify(firebase).logEvent(eq("test_event_dashed"), bundleEq(new Bundle()));
+    }
+
+    @Test
+    public void makeKeyWithDot() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test.event").build());
+        verify(firebase).logEvent(eq("test_event"), bundleEq(new Bundle()));
+    }
+
     /**
      * Uses the string representation of the object. Useful for JSON objects.
      * @param expected Expected object


### PR DESCRIPTION
I have added a check to replace the dash with underscore inside `makeKey()` method to follow the documentation specs.