### PR TITLE
[STRATCONN-161] Map - to _ in properties and event names  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.1.1 / 2020-04-21
+==================
+  * Adds check on `makeKey` to replace `-` to `_` on properties and event names.
+
 2.1.0 / 2020-02-20
 ==================
   * Add support for explicitly tracking screen calls.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=2.1.0-SNAPSHOT
+VERSION=2.1.1-SNAPSHOT
 
 POM_ARTIFACT_ID=firebase
 POM_PACKAGING=aar

--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -215,6 +215,8 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   public static String makeKey(String key) {
     if (key.contains(".")) {
       key = key.trim().replace(".", "_");
+    } else if (key.contains("-")) {
+      key = key.trim().replace("-", "_");
     } else {
       key = key.trim().replaceAll(" ", "_");
     }

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -157,6 +157,18 @@ public class FirebaseTest {
         verify(firebase).setCurrentScreen(any(Activity.class), eq("home_screen"), (String) isNull());
     }
 
+    @Test
+    public void makeKeyWithDash() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test-event-dashed").build());
+        verify(firebase).logEvent(eq("test_event_dashed"), bundleEq(new Bundle()));
+    }
+
+    @Test
+    public void makeKeyWithDot() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test.event").build());
+        verify(firebase).logEvent(eq("test_event"), bundleEq(new Bundle()));
+    }
+
     /**
      * Uses the string representation of the object. Useful for JSON objects.
      * @param expected Expected object


### PR DESCRIPTION
**NOTE: Changes were migrated from PR https://github.com/segment-integrations/analytics-android-integration-firebase/pull/28 to update SNAPSHOT and prep for release.**

"I have added a check to replace the dash with underscore inside makeKey() method to follow the documentation specs." 

Adds support replace `-` with `_` in properties and event names to be in compliance with Firebase formatting. We currently do this for whitespace and `.`. 