### PR TITLE
Logic to catch multiple forbidden chars

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -213,13 +213,13 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   }
 
   public static String makeKey(String key) {
-    if (key.contains(".")) {
-      key = key.trim().replace(".", "_");
-    } else if (key.contains("-")) {
-      key = key.trim().replace("-", "_");
-    } else {
-      key = key.trim().replaceAll(" ", "_");
+    String[] forbiddenChars = {".", "-", " "};
+    for (String forbidden : forbiddenChars) {
+      if (key.contains(forbidden)) {
+        key = key.trim().replace(forbidden, "_");
+      }
     }
+
     return key.substring(0, Math.min(key.length(), 40));
   }
 }

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -169,6 +169,12 @@ public class FirebaseTest {
         verify(firebase).logEvent(eq("test_event"), bundleEq(new Bundle()));
     }
 
+    @Test
+    public void makeKeyWithDashAndDot() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test-event-dashed-and.dotted").build());
+        verify(firebase).logEvent(eq("test_event_dashed_and_dotted"), bundleEq(new Bundle()));
+    }
+
     /**
      * Uses the string representation of the object. Useful for JSON objects.
      * @param expected Expected object

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -170,6 +170,12 @@ public class FirebaseTest {
     }
 
     @Test
+    public void makeKeyWithSpace() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test event").build());
+        verify(firebase).logEvent(eq("test_event"), bundleEq(new Bundle()));
+    }
+
+    @Test
     public void makeKeyWithDashAndDot() {
         integration.track(new TrackPayload.Builder().anonymousId("12345").event("test-event-dashed-and.dotted").build());
         verify(firebase).logEvent(eq("test_event_dashed_and_dotted"), bundleEq(new Bundle()));


### PR DESCRIPTION
Currently an evnet name like `test-event-dashed-and.dotted` will not be fully transformed to underscores which results in the event being rejected.

Using replace instead of the replaceAll for the whitespace check. Not sure if I am missing something form the original implementation for that. 