### PR TITLE
Apply correct transformation for Products Searched event

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -80,7 +80,7 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
     EVENT_MAPPER.put("Product Added to Wishlist", Event.ADD_TO_WISHLIST);
     EVENT_MAPPER.put("Product Shared", Event.SHARE);
     EVENT_MAPPER.put("Product Clicked", Event.SELECT_CONTENT);
-    EVENT_MAPPER.put("Product Searched", Event.SEARCH);
+    EVENT_MAPPER.put("Products Searched", Event.SEARCH);
     return EVENT_MAPPER;
   }
 

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -148,6 +148,12 @@ public class FirebaseTest {
     }
 
     @Test
+    public void productsSearchedTransformation() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("Products Searched").build());
+        verify(firebase).logEvent(eq("search"), bundleEq(new Bundle()));
+    }
+
+    @Test
     public void trackScreenWithName() {
         final Activity activity = PowerMockito.mock(Activity.class);
         integration.onActivityStarted(activity);


### PR DESCRIPTION
As per our Firebase docs we map the Products Searched event to the native Firebase method: https://segment.com/docs/connections/destinations/catalog/firebase/#event-mappings

This was mapped incorrectly as `Product Searched`. It should be `Products Searched`.