### PR TITLE
`makeKey` Add restriction for `:`

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -214,7 +214,7 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
   }
 
   public static String makeKey(String key) {
-    String[] forbiddenChars = {".", "-", " "};
+    String[] forbiddenChars = {".", "-", " ", ":"};
     for (String forbidden : forbiddenChars) {
       if (key.contains(forbidden)) {
         key = key.trim().replace(forbidden, "_");

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -205,6 +205,12 @@ public class FirebaseTest {
         verify(firebase).logEvent(eq("test_event_dashed_and_dotted"), bundleEq(new Bundle()));
     }
 
+    @Test
+    public void makeKeyWithColon() {
+        integration.track(new TrackPayload.Builder().anonymousId("12345").event("test:colon").build());
+        verify(firebase).logEvent(eq("test_colon"), bundleEq(new Bundle()));
+    }
+
     /**
      * Uses the string representation of the object. Useful for JSON objects.
      * @param expected Expected object


### PR DESCRIPTION
as per #31, `:` is not allowed in firebase key names. This change adds `:` to the list of forbidden characters when transforming the key

Closes #31 