### PR TITLE
Catch null products

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import static com.segment.analytics.internal.Utils.hasPermission;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
+import static java.util.Objects.isNull;
 
 /**
  * Google Analytics for Firebase is a free app measurement solution that provides insight on app
@@ -211,7 +212,7 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
       } else {
         property = makeKey(property);
       }
-      if (property.equals(Param.ITEMS)) {
+      if (property.equals(Param.ITEMS) && value != null) {
         List<ValueMap> products = properties.getList("products", ValueMap.class);
         ArrayList<Bundle> mappedProducts = formatProducts(products);
         bundle.putParcelableArrayList(property, mappedProducts);

--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import static com.segment.analytics.internal.Utils.hasPermission;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
-import static java.util.Objects.isNull;
 
 /**
  * Google Analytics for Firebase is a free app measurement solution that provides insight on app

--- a/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/firebase/FirebaseTest.java
@@ -153,6 +153,23 @@ public class FirebaseTest {
     }
 
     @Test
+    public void trackPurchaseWithNullProducts() {
+        Properties properties = new Properties()
+                .putValue("revenue", 100.0)
+                .putValue("currency", "USD")
+                .putValue("products", null);
+
+        integration.track(new TrackPayload.Builder().anonymousId("1234").properties(properties).event("Order Completed").build());
+
+        Bundle expected = new Bundle();
+        expected.putDouble("value", 100.0);
+        expected.putString("currency", "USD");
+        expected.putString("items", null);
+
+        verify(firebase).logEvent(eq("purchase"), bundleEq(expected));
+    }
+
+    @Test
     public void trackWithEventNameTransformation() {
         Properties properties = new Properties()
                 .putValue("integer", 1)


### PR DESCRIPTION
If products are passed as a null value it will cause a fatal exception in app. For example:
Analytics.with(this).track("Cart Viewed", new Properties()
                .putValue("products", null));

Will throw the following exception:

2021-09-01 14:57:49.425 19542-19542/com.example.firebase E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.example.firebase, PID: 19542
    java.lang.NullPointerException: Attempt to invoke interface method 'java.util.Iterator java.util.List.iterator()' on a null object reference
        at com.segment.analytics.android.integrations.firebase.FirebaseIntegration.formatProducts(FirebaseIntegration.java:227)
