### PR TITLE
add null check on formatProducts

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java
@@ -224,6 +224,8 @@ public class FirebaseIntegration extends Integration<FirebaseAnalytics> {
 
   private static ArrayList<Bundle> formatProducts(List<ValueMap> products) {
     ArrayList<Bundle> mappedProducts = new ArrayList<>();
+    if (products == null) return mappedProducts;
+
     for (ValueMap product : products) {
       Bundle mappedProduct = new Bundle();
       for (Map.Entry<String, Object> innerEntry : product.entrySet()) {


### PR DESCRIPTION
per #40, a null `products` value could break the SDK with a NPE. this branch patches a null check to prevent that from happening